### PR TITLE
Updating Parser function of number.js to fix issue #147

### DIFF
--- a/src/global/number/number.js
+++ b/src/global/number/number.js
@@ -28,7 +28,7 @@ function NumberMaskDirective($locale, $parse, PreFormatters, NumberMasks) {
                 var actualNumber;
                 var formattedValue;
 
-                if (value === '-') {
+                if (angular.isDefined(attrs.uiNegativeNumber) && value === '-') {
                     actualNumber = value;
                     formattedValue = value;
                 }


### PR DESCRIPTION
Updating Parser function of number.js to fix issue #147

In a negative number scenario, I want to start by entering minus sign followed by number, but this is not working as on 1st minus sign, it shows 0 and then I have to enter some number after that only I can enter minus sign.

Another problem is, if negative number is in input field and if I want to make it positive by hitting minus sign then my cursor must be at the end, if it is at the start or in mid then it is not working.
